### PR TITLE
Quoting name of course to disarm potential semicolons.

### DIFF
--- a/collect_course_data/index.js
+++ b/collect_course_data/index.js
@@ -483,7 +483,7 @@ async function start () {
     const courseData = [
       courseId,
       course.sis_course_id,
-      course.name,
+      `"${course.name}"`,
       courseCode,
       getCourseURL(courseId),
       getSchoolName(courseAccountName),


### PR DESCRIPTION
There were some courses with names containing semicolons. This should make it easier for e.g. spreadsheet applications to interpret the data.